### PR TITLE
VS2022

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -26,7 +26,7 @@ for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version ^[1
   set "VSINSTALLDIR=%%i\"
 )
 if not exist "%VSINSTALLDIR%" (
-    :: VS2019 install but with vs2017 compiler stuff installed
+    :: VS2022 install but with vs2017/vs2019 compiler stuff installed
 	for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -requires Microsoft.VisualStudio.Component.VC.v143.x86.x64 -property installationPath`) do (
 	:: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
 	set "VSINSTALLDIR=%%i\"
@@ -60,7 +60,7 @@ for /F %%i in ('dir /ON /B "%WindowsSdkDir%\include"') DO (
   )
 )
 if errorlevel 1 (
-    echo "Didn't find any windows 10/11 SDK. I'm not sure if things will work, but let's try..."
+    echo "Didn't find any windows 10 SDK. I'm not sure if things will work, but let's try..."
 ) else (
     echo Windows SDK version found as: "%WindowsSDKVer%"
 )
@@ -75,7 +75,7 @@ IF "@cross_compiler_target_platform@" == "win-64" (
 
 pushd %VSINSTALLDIR%
 set VSCMD_DEBUG=1
-CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.3 %WindowsSDKVer%
+CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.40 %WindowsSDKVer%
 popd
 
 IF "%CMAKE_GENERATOR%" == "" SET "CMAKE_GENERATOR=%CMAKE_GEN%"

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -66,11 +66,11 @@ if errorlevel 1 (
 )
 
 IF "@cross_compiler_target_platform@" == "win-64" (
-  set "CMAKE_GEN=Visual Studio @VER@ @YEAR@ Win64"
   set "BITS=64"
+  set "CMAKE_PLAT=Win64"
 ) else (
-  set "CMAKE_GEN=Visual Studio @VER@ @YEAR@"
   set "BITS=32"
+  set "CMAKE_PLAT=Win32"
 )
 
 pushd %VSINSTALLDIR%
@@ -78,7 +78,14 @@ set VSCMD_DEBUG=1
 CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.40 %WindowsSDKVer%
 popd
 
+:: CMAKE configuration
+:: See: https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
+:: See: https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_TOOLSET.html
+:: See: https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_PLATFORM.html
+set "CMAKE_GEN=Visual Studio @VER@ @YEAR@"
 IF "%CMAKE_GENERATOR%" == "" SET "CMAKE_GENERATOR=%CMAKE_GEN%"
+IF "%CMAKE_GENERATOR_PLATFORM%" == "" SET "CMAKE_GENERATOR_PLATFORM=%CMAKE_PLAT%"
+IF "%CMAKE_GENERATOR_TOOLSET%" == "" SET "CMAKE_GENERATOR_TOOLSET=v143"
 
 :GetWin10SdkDir
 call :GetWin10SdkDirHelper HKLM\SOFTWARE\Wow6432Node > nul 2>&1

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -4,9 +4,9 @@ SET DISTUTILS_USE_SDK=1
 :: This is probably not good. It is for the pre-UCRT msvccompiler.py *not* _msvccompiler.py
 SET MSSdk=1
 
-SET "VS_VERSION=17.10"
-SET "VS_MAJOR=17"
-SET "VS_YEAR=2022"
+SET "VS_VERSION=@VER@.@update_version@"
+SET "VS_MAJOR=@VER@"
+SET "VS_YEAR=@YEAR@"
 
 set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
 set "MSYS2_ENV_CONV_EXCL=CL"

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -4,9 +4,9 @@ SET DISTUTILS_USE_SDK=1
 :: This is probably not good. It is for the pre-UCRT msvccompiler.py *not* _msvccompiler.py
 SET MSSdk=1
 
-SET "VS_VERSION=16.5"
-SET "VS_MAJOR=16"
-SET "VS_YEAR=2019"
+SET "VS_VERSION=17.10"
+SET "VS_MAJOR=17"
+SET "VS_YEAR=2022"
 
 set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
 set "MSYS2_ENV_CONV_EXCL=CL"
@@ -20,29 +20,29 @@ set "CXX=cl.exe"
 set "CC=cl.exe"
 
 set "VSINSTALLDIR="
-:: Try to find actual vs2017 installations
-for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version ^[16.0^,17.0^] -property installationPath`) do (
+:: Try to find actual vs2022 installations
+for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version ^[17.0^,18.0^] -property installationPath`) do (
   :: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
   set "VSINSTALLDIR=%%i\"
 )
 if not exist "%VSINSTALLDIR%" (
     :: VS2019 install but with vs2017 compiler stuff installed
-	for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -requires Microsoft.VisualStudio.Component.VC.v142.x86.x64 -property installationPath`) do (
+	for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -requires Microsoft.VisualStudio.Component.VC.v143.x86.x64 -property installationPath`) do (
 	:: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
 	set "VSINSTALLDIR=%%i\"
 	)
 )
 if not exist "%VSINSTALLDIR%" (
-set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\"
+set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Professional\"
 )
 if not exist "%VSINSTALLDIR%" (
-set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\"
+set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Community\"
 )
 if not exist "%VSINSTALLDIR%" (
-set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\"
+set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools\"
 )
 if not exist "%VSINSTALLDIR%" (
-set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\"
+set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\"
 )
 
 IF NOT "%CONDA_BUILD%" == "" (
@@ -60,7 +60,7 @@ for /F %%i in ('dir /ON /B "%WindowsSdkDir%\include"') DO (
   )
 )
 if errorlevel 1 (
-    echo "Didn't find any windows 10 SDK. I'm not sure if things will work, but let's try..."
+    echo "Didn't find any windows 10/11 SDK. I'm not sure if things will work, but let's try..."
 ) else (
     echo Windows SDK version found as: "%WindowsSDKVer%"
 )
@@ -75,7 +75,7 @@ IF "@cross_compiler_target_platform@" == "win-64" (
 
 pushd %VSINSTALLDIR%
 set VSCMD_DEBUG=1
-CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.2 %WindowsSDKVer%
+CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.3 %WindowsSDKVer%
 popd
 
 IF "%CMAKE_GENERATOR%" == "" SET "CMAKE_GENERATOR=%CMAKE_GEN%"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,9 +7,9 @@ update_version:
   - 10
 # this is the version number reported by cl.exe
 cl_version:
-  - 19.29.30154
+  - 19.40.33813
 # this version follows the version number reported for the vcruntim140.dll file.
-#     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Redist\MSVC\14.15.26706\x64\Microsoft.VC141.CRT
+#     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.40.33807\x64\Microsoft.VC143.CRT
 #     Note the 14.15.26706 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
 tools_version:
   - 14.40.33807

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,6 +11,8 @@ cl_version:
 # this version follows the version number reported for the vcruntim140.dll file.
 #     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.40.33807\x64\Microsoft.VC143.CRT
 #     Note the 14.40.33807 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
+tools_version:
+  - 14.40.33807
 runtime_version:
   - 14.40.33807
 # SDK release page: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,11 +10,10 @@ cl_version:
   - 19.40.33813
 # this version follows the version number reported for the vcruntim140.dll file.
 #     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.40.33807\x64\Microsoft.VC143.CRT
-#     Note the 14.15.26706 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
-tools_version:
-  - 14.40.33807
+#     Note the 14.40.33807 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
 runtime_version:
   - 14.40.33807
+# SDK release page: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/
 sdk_version:
   - 10.0.26100.0
 # we could zip all these together, and we should do that if there's ever more than one version supported at once.  I don't think that's currently possible, though.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,10 +1,10 @@
 YEAR:
-  - 2019
+  - 2022
 VER:
-  - 16
+  - 17
 # the VS update version.  This is the middle digit in the version reported in the VS help->about UI.  It is perhaps a more readily referenceable number.
 update_version:
-  - 11
+  - 10
 # this is the version number reported by cl.exe
 cl_version:
   - 19.29.30154
@@ -12,8 +12,9 @@ cl_version:
 #     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Redist\MSVC\14.15.26706\x64\Microsoft.VC141.CRT
 #     Note the 14.15.26706 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
 tools_version:
-#  - 14.25.28610
-  - 14.29.30133
+  - 14.40.33807
 runtime_version:
-  - 14.29.30133
+  - 14.40.33807
+sdk_version:
+  - 10.0.26100.0
 # we could zip all these together, and we should do that if there's ever more than one version supported at once.  I don't think that's currently possible, though.

--- a/recipe/install_activate.bat
+++ b/recipe/install_activate.bat
@@ -3,5 +3,6 @@ COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compile
 pushd "%PREFIX%\etc\conda\activate.d"
 sed -i 's/@YEAR@/%YEAR%/g' vs%YEAR%_compiler_vars.bat
 sed -i 's/@VER@/%VER%/g' vs%YEAR%_compiler_vars.bat
+sed -i 's/@update_version@/%update_version%/g' vs%YEAR%_compiler_vars.bat
 sed -i 's/@cross_compiler_target_platform@/%cross_compiler_target_platform%/g' vs%YEAR%_compiler_vars.bat
 popd

--- a/recipe/install_runtime.bat
+++ b/recipe/install_runtime.bat
@@ -46,7 +46,6 @@ robocopy "%REDIST_ROOT%\Microsoft.VC%VC_VER%.OpenMP" "%PREFIX%" *.dll /E
 if %ERRORLEVEL% GTR 8 exit 1
 
 REM ========== REQUIRES Win 10/11 SDK be installed, or files otherwise copied to location below!
-C:\Program Files (x86)\Windows Kits\10\Redist\%sdk_version%\ucrt\DLLs\%VC_PATH%
 robocopy "C:\Program Files (x86)\Windows Kits\10\Redist\%sdk_version%\ucrt\DLLs\%VC_PATH%"  "%LIBRARY_BIN%" *.dll /E
 if %ERRORLEVEL% GEQ 8 exit 1
 robocopy "C:\Program Files (x86)\Windows Kits\10\Redist\%sdk_version%\ucrt\DLLs\%VC_PATH%"  "%PREFIX%" *.dll /E

--- a/recipe/install_runtime.bat
+++ b/recipe/install_runtime.bat
@@ -7,13 +7,13 @@ if "%ARCH%"=="64" (
    set VC_PATH=x64
 )
 
-set MSC_VER=2019
+set MSC_VER=2022
 
-REM ========== This one comes from visual studio 2017
-set "VC_VER=142"
+REM ========== This one comes from visual studio 2022
+set "VC_VER=143"
 
 set "BT_ROOT="
-for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version ^[16.0^,17.0^] -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version ^[17.0^,18.0^] -property installationPath`) do (
   :: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
   set "BT_ROOT=%%i\"
 )
@@ -45,10 +45,11 @@ if %ERRORLEVEL% GTR 8 exit 1
 robocopy "%REDIST_ROOT%\Microsoft.VC%VC_VER%.OpenMP" "%PREFIX%" *.dll /E
 if %ERRORLEVEL% GTR 8 exit 1
 
-REM ========== REQUIRES Win 10 SDK be installed, or files otherwise copied to location below!
-robocopy "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\%VC_PATH%"  "%LIBRARY_BIN%" *.dll /E
+REM ========== REQUIRES Win 10/11 SDK be installed, or files otherwise copied to location below!
+C:\Program Files (x86)\Windows Kits\10\Redist\%sdk_version%\ucrt\DLLs\%VC_PATH%
+robocopy "C:\Program Files (x86)\Windows Kits\10\Redist\%sdk_version%\ucrt\DLLs\%VC_PATH%"  "%LIBRARY_BIN%" *.dll /E
 if %ERRORLEVEL% GEQ 8 exit 1
-robocopy "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\%VC_PATH%"  "%PREFIX%" *.dll /E
+robocopy "C:\Program Files (x86)\Windows Kits\10\Redist\%sdk_version%\ucrt\DLLs\%VC_PATH%"  "%PREFIX%" *.dll /E
 if %ERRORLEVEL% GEQ 8 exit 1
-COPY "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\%VC_PATH%\ucrtbase.dll" "%LIBRARY_BIN%"
-COPY "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\%VC_PATH%\ucrtbase.dll" "%PREFIX%"
+COPY "C:\Program Files (x86)\Windows Kits\10\Redist\%sdk_version%\ucrt\DLLs\%VC_PATH%\ucrtbase.dll" "%LIBRARY_BIN%"
+COPY "C:\Program Files (x86)\Windows Kits\10\Redist\%sdk_version%\ucrt\DLLs\%VC_PATH%\ucrtbase.dll" "%PREFIX%"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-# version numbering is explained at https://stackoverflow.com/questions/42730478/version-numbers-for-visual-studio-2017-boost-and-cmake
+# version numbering is explained at https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/
 #     This version number follows the "platform toolset"
-{% set vcver="14.3" %}
+{% set vcver="14.40" %}
 {% set vsyear="2022" %}
 # VS2022 is fundamentally compatible with VS2015.  We name our package vs2015_runtime so that it can't be
 #    mixed up with the runtime from VS2015 - you do actually need VS2017 runtime for things compiled with

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ outputs:
     about:
       summary: MSVC runtimes associated with cl.exe version {{ cl_version  }} (VS {{ vsyear }} update {{ update_version }})
   - name: vc
-    version: {{ vcver }}
+    version: "{{ vcver }}"
     build:
       track_features:
         - vc{{ vcver.split(".")[0] }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,10 +25,10 @@ outputs:
       run_exports:
         strong:
           # compatible within major version.  This is MSFT's incrementing of the UCRT version.  It was
-          #    14.0 with VS2015, 14.1 with VS2017, and 14.2 with VS2019 - if the major version changes, we're assuming
-          #    that binary compatibility breaks.  This has a minimum bound equal to vcver, so building with
-          #    vs2017 here will require the vs2017-era runtime (the package is named vs2015_runtime, but the
-          #    version differs)
+          #    14.0 with VS2015, 14.1 with VS2017, 14.2 with VS2019 and now 14.40 with VS2022.
+          #    If the major version changes, we're assuming that binary compatibility breaks.  
+          #    This has a minimum bound equal to vcver, so building with vs2022 here will require 
+          #    the vs2022-era runtime (the package is named vs2015_runtime, but the version differs)
           - {{ pin_subpackage('vc') }}
           - {{ pin_subpackage('vs' + runtime_year + '_runtime') }}
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
 # version numbering is explained at https://stackoverflow.com/questions/42730478/version-numbers-for-visual-studio-2017-boost-and-cmake
 #     This version number follows the "platform toolset"
-{% set vcver="14.2" %}
-{% set vsyear="2019" %}
-# VS2019 is fundamentally compatible with VS2015.  We name our package vs2015_runtime so that it can't be
+{% set vcver="14.3" %}
+{% set vsyear="2022" %}
+# VS2022 is fundamentally compatible with VS2015.  We name our package vs2015_runtime so that it can't be
 #    mixed up with the runtime from VS2015 - you do actually need VS2017 runtime for things compiled with
-#    VS2017, and the runtime we have here is backwards-compatible with things compiled with VS2015.
+#    VS2019, VS2017, and the runtime we have here is backwards-compatible with things compiled with VS2015.
 {% set runtime_year="2015" %}
 
 package:
@@ -13,7 +13,7 @@ package:
 
 build:
   skip: True # [not win]
-  number: 4
+  number: 0
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}
@@ -25,7 +25,7 @@ outputs:
       run_exports:
         strong:
           # compatible within major version.  This is MSFT's incrementing of the UCRT version.  It was
-          #    14.0 with VS2015, and 14.1 with VS2017 - if the major version changes, we're assuming
+          #    14.0 with VS2015, 14.1 with VS2017, and 14.2 with VS2019 - if the major version changes, we're assuming
           #    that binary compatibility breaks.  This has a minimum bound equal to vcver, so building with
           #    vs2017 here will require the vs2017-era runtime (the package is named vs2015_runtime, but the
           #    version differs)


### PR DESCRIPTION
vs2022 activation scripts + vs2015 updated runtime.

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-4649

### Explanation of changes:

- Follow the same pattern as vs2019. Tested changes on a dev instance.
