### PR TITLE
Set vcvars_ver to 14.41

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -66,11 +66,9 @@ if errorlevel 1 (
 )
 
 IF "@cross_compiler_target_platform@" == "win-64" (
-  set "target_platform=amd64"
   set "BITS=64"
   set "CMAKE_PLAT=Win64"
 ) else (
-  set "target_platform=x86"
   set "BITS=32"
   set "CMAKE_PLAT=Win32"
 )

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -66,16 +66,18 @@ if errorlevel 1 (
 )
 
 IF "@cross_compiler_target_platform@" == "win-64" (
+  set "target_platform=amd64"
   set "BITS=64"
   set "CMAKE_PLAT=Win64"
 ) else (
+  set "target_platform=x86"
   set "BITS=32"
   set "CMAKE_PLAT=Win32"
 )
 
 pushd %VSINSTALLDIR%
 set VSCMD_DEBUG=1
-CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.40 %WindowsSDKVer%
+CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.41 %WindowsSDKVer%
 popd
 
 :: CMAKE configuration

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,7 +12,7 @@ cl_version:
 #     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.40.33807\x64\Microsoft.VC143.CRT
 #     Note the 14.40.33807 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
 tools_version:
-  - 14.40.33807
+  - 14.41.34120
 runtime_version:
   - 14.40.33807
 # SDK release page: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 build:
   skip: True # [not win]
-  number: 0
+  number: 1
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}


### PR DESCRIPTION
The toolset is 14.41 and not 14.40. As 14.40 is not on the AMI, it was still picking up 14.41, but was printing an error message.