### PR TITLE
loosen toolset restriction

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -75,7 +75,7 @@ IF "@cross_compiler_target_platform@" == "win-64" (
 
 pushd %VSINSTALLDIR%
 set VSCMD_DEBUG=1
-CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.4 %WindowsSDKVer%
+CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=@tools_version@ %WindowsSDKVer%
 popd
 
 :: CMAKE configuration

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -75,7 +75,7 @@ IF "@cross_compiler_target_platform@" == "win-64" (
 
 pushd %VSINSTALLDIR%
 set VSCMD_DEBUG=1
-CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.41 %WindowsSDKVer%
+CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.4 %WindowsSDKVer%
 popd
 
 :: CMAKE configuration

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -17,5 +17,5 @@ runtime_version:
   - 14.42.34433
 # SDK release page: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/
 sdk_version:
-  - 10.0.26100.0
+  - 10.0.22621.0
 # we could zip all these together, and we should do that if there's ever more than one version supported at once.  I don't think that's currently possible, though.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,7 +12,7 @@ cl_version:
 #     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.40.33807\x64\Microsoft.VC143.CRT
 #     Note the 14.40.33807 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
 tools_version:
-  - 14.42.34433
+  - 14.4
 runtime_version:
   - 14.42.34433
 # SDK release page: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,9 +12,9 @@ cl_version:
 #     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.40.33807\x64\Microsoft.VC143.CRT
 #     Note the 14.40.33807 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
 tools_version:
-  - 14.41.34120
+  - 14.42.34433
 runtime_version:
-  - 14.40.33807
+  - 14.42.34433
 # SDK release page: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/
 sdk_version:
   - 10.0.26100.0

--- a/recipe/install_activate.bat
+++ b/recipe/install_activate.bat
@@ -5,4 +5,5 @@ sed -i 's/@YEAR@/%YEAR%/g' vs%YEAR%_compiler_vars.bat
 sed -i 's/@VER@/%VER%/g' vs%YEAR%_compiler_vars.bat
 sed -i 's/@update_version@/%update_version%/g' vs%YEAR%_compiler_vars.bat
 sed -i 's/@cross_compiler_target_platform@/%cross_compiler_target_platform%/g' vs%YEAR%_compiler_vars.bat
+sed -i 's/@tools_version@/%tools_version%/g' vs%YEAR%_compiler_vars.bat
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 build:
   skip: True # [not win]
-  number: 1
+  number: 2
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}


### PR DESCRIPTION
vs2022 toolsets are in the 14.40 serie. A recent update on the builder installed toolset 14.42 instead of previous 14.41.
Setting -vcvars_ver=14.4 correctly results in VCToolsVersion=14.42.34433 