### PR TITLE
Update activate.bat

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -80,7 +80,7 @@ IF "@cross_compiler_target_platform@" == "win-64" (
 
 pushd %VSINSTALLDIR%
 set VSCMD_DEBUG=1
-CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.41 %WindowsSDKVer%
+CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=14.42 %WindowsSDKVer%
 popd
 
 :: CMAKE configuration

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -49,6 +49,11 @@ IF NOT "%CONDA_BUILD%" == "" (
   set "INCLUDE=%LIBRARY_INC%;%INCLUDE%"
   set "LIB=%LIBRARY_LIB%;%LIB%"
   set "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%CMAKE_PREFIX_PATH%"
+) else (
+  :: normal environment
+  set "INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%"
+  set "LIB=%CONDA_PREFIX%\Library\lib;%LIB%"
+  set "CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library;%CMAKE_PREFIX_PATH%"
 )
 
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,15 +7,15 @@ update_version:
   - 10
 # this is the version number reported by cl.exe
 cl_version:
-  - 19.40.33813
+  - 19.42.34436
 # this version follows the version number reported for the vcruntim140.dll file.
-#     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.40.33807\x64\Microsoft.VC143.CRT
-#     Note the 14.40.33807 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
+#     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.42.34433\x64\Microsoft.VC143.CRT
+#     Note the 14.42.34433 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
 tools_version:
   - 14.41.34120
 runtime_version:
-  - 14.40.33807
+  - 14.42.34433
 # SDK release page: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/
 sdk_version:
-  - 10.0.26100.0
+  - 10.0.22621.0
 # we could zip all these together, and we should do that if there's ever more than one version supported at once.  I don't think that's currently possible, though.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 build:
   skip: True # [not win]
-  number: 1
+  number: 2
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # version numbering is explained at https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/
 #     This version number follows the "platform toolset"
-{% set vcver="14.40" %}
+{% set vcver="14.42" %}
 {% set vsyear="2022" %}
 # VS2022 is fundamentally compatible with VS2015.  We name our package vs2015_runtime so that it can't be
 #    mixed up with the runtime from VS2015 - you do actually need VS2017 runtime for things compiled with


### PR DESCRIPTION
## Changes
- Fixes https://github.com/AnacondaRecipes/pytorch-feedstock/issues/55
- Sets `INCLUDE`, `LIB` and `CMAKE_PREFIX_PATH` to the correct paths. Useful for feedstocks that use this compiler during runtime or in tests. 
- Updates SDK and runtime versions to versions that are available on the current AMIs

Related: https://github.com/AnacondaRecipes/vs2019-feedstock/pull/4