### PR TITLE
Attempt at a deactivation script.

### DIFF
--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,0 +1,26 @@
+@echo off
+:: Ensure delayed variable expansion
+setlocal enabledelayedexpansion
+
+:: CMAKE_PREFIX_PATH is set for both the build and runtime environments.
+:: Unlike the build environment, there is a chance that CMAKE_PREFIX_PATH
+:: gets modified after activation, but before deactivation. For this reason 
+:: we are removing the conda library path from CMAKE_PREFIX_PATH that we added 
+:: instead of restoring the value that was saved in the activation script.
+
+:: Initialize a new variable to store the cleaned path
+set "NEW_CMAKE_PREFIX_PATH="
+
+:: Iterate through each path entry
+for %%I in (%CMAKE_PREFIX_PATH%) do (
+    if /I not "%%I"=="%CONDA_PREFIX%\Library" (
+        if defined NEW_CMAKE_PREFIX_PATH (
+            set "NEW_CMAKE_PREFIX_PATH=!NEW_CMAKE_PREFIX_PATH!;%%I"
+        ) else (
+            set "NEW_CMAKE_PREFIX_PATH=%%I"
+        )
+    )
+)
+
+:: Disable setlocal so changes persist
+endlocal & set "CMAKE_PREFIX_PATH=%NEW_CMAKE_PREFIX_PATH%"

--- a/recipe/install_activate.bat
+++ b/recipe/install_activate.bat
@@ -1,3 +1,4 @@
+:: Activation script
 mkdir "%PREFIX%\etc\conda\activate.d"
 COPY "%RECIPE_DIR%\activate.bat" "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
 pushd "%PREFIX%\etc\conda\activate.d"
@@ -7,3 +8,7 @@ sed -i 's/@update_version@/%update_version%/g' vs%YEAR%_compiler_vars.bat
 sed -i 's/@cross_compiler_target_platform@/%cross_compiler_target_platform%/g' vs%YEAR%_compiler_vars.bat
 sed -i 's/@tools_version@/%tools_version%/g' vs%YEAR%_compiler_vars.bat
 popd
+
+:: Deactivation script
+mkdir %PREFIX%\etc\conda\deactivate.d
+copy %RECIPE_DIR%\deactivate.bat %PREFIX%\etc\conda\deactivate.d\~vs%YEAR%_compiler_deactivate.bat

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 build:
   skip: True # [not win]
-  number: 3
+  number: 4
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}


### PR DESCRIPTION
Fixes #5 That set `CMAKE_PREFIX_PATH` in the runtime env, but  didn't clean up when switching environments.

## Changes
- Bump build number
- Adds a deactivate script
- Removes the entry to `CMAKE_PREFIX_PATH` that was added in activation (if it exists) during deactivation.


## Reproduce

```
conda create -n vs2022_1 -y vs2022_win-64
conda create -n vs2022_2 -y vs2022_win-64
conda activate vs2022_1
conda activate vs2022_2
echo %CMAKE_PREFIX_PATH%

C:\miniconda3\envs\vs2022_2\Library;C:\miniconda3\envs\vs2022_1\Library;
```

## Test fix

```
conda activate base
set CMAKE_PREFIX_PATH=
conda create -n vs2022_1 -y vs2022_win-64 -c https://staging.continuum.io/prefect/fs/vs2022-feedstock/pr6/f33233d
conda create -n vs2022_2 -y vs2022_win-64 -c https://staging.continuum.io/prefect/fs/vs2022-feedstock/pr6/f33233d
conda activate vs2022_1
conda activate vs2022_2
echo %CMAKE_PREFIX_PATH%

C:\miniconda3\envs\vs2022_2\Library;
```

