### PR TITLE
Force using v14.42 build tools

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -27,7 +27,7 @@ for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version ^[1
 )
 if not exist "%VSINSTALLDIR%" (
     :: VS2022 install but with vs2017/vs2019 compiler stuff installed
-	for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -requires Microsoft.VisualStudio.Component.VC.v143.x86.x64 -property installationPath`) do (
+	for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -requires Microsoft.VisualStudio.Component.VC.v@msvc_version@.x86.x64 -property installationPath`) do (
 	:: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
 	set "VSINSTALLDIR=%%i\"
 	)
@@ -90,7 +90,7 @@ popd
 set "CMAKE_GEN=Visual Studio @VER@ @YEAR@"
 IF "%CMAKE_GENERATOR%" == "" SET "CMAKE_GENERATOR=%CMAKE_GEN%"
 IF "%CMAKE_GENERATOR_PLATFORM%" == "" SET "CMAKE_GENERATOR_PLATFORM=%CMAKE_PLAT%"
-IF "%CMAKE_GENERATOR_TOOLSET%" == "" SET "CMAKE_GENERATOR_TOOLSET=v143"
+IF "%CMAKE_GENERATOR_TOOLSET%" == "" SET "CMAKE_GENERATOR_TOOLSET=v@msvc_version@"
 
 :GetWin10SdkDir
 call :GetWin10SdkDirHelper HKLM\SOFTWARE\Wow6432Node > nul 2>&1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,21 +1,32 @@
+# ATTENTION: Make sure to keep values in step with what is installed into our win-64 CI and dev images at
+# https://github.com/anaconda-distribution/rocket-platform/blob/main/machine-images/win-64/install_vsc_2022.ps1#L44
+# At least one of the installed components should be of the form:
+# Microsoft.VisualStudio.Component.VC.<tools_version>.<VER>.<update_version>.x86.x64
+
 YEAR:
   - 2022
 VER:
   - 17
-# the VS update version.  This is the middle digit in the version reported in the VS help->about UI.  It is perhaps a more readily referenceable number.
+# the VS update version.  This is the middle digit in the version reported in the VS help->about UI.  It is perhaps a
+# more readily referenceable number.
 update_version:
-  - 10
+  - 12
 # this is the version number reported by cl.exe
 cl_version:
-  - 19.42.34436
+  - 19.42.34440
+tools_version:
+  - 14.42
+# Installed as "MSVC v143 - VS 2022 C++ x64/x86 build tools" via the Visual Studio Installer
+msvc_version:
+  - 143
 # this version follows the version number reported for the vcruntim140.dll file.
 #     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.40.33807\x64\Microsoft.VC143.CRT
-#     Note the 14.40.33807 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
-tools_version:
-  - 14.4
+#     Note the 14.40.33807 in there - that's what we want, but in case their folder scheme changes, it's better to
+#     base it on the version of the file itself.
 runtime_version:
   - 14.42.34433
 # SDK release page: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/
 sdk_version:
   - 10.0.22621.0
-# we could zip all these together, and we should do that if there's ever more than one version supported at once.  I don't think that's currently possible, though.
+# we could zip all these together, and we should do that if there's ever more than one version supported at once. I
+# don't think that's currently possible, though.

--- a/recipe/install_activate.bat
+++ b/recipe/install_activate.bat
@@ -7,6 +7,7 @@ sed -i 's/@VER@/%VER%/g' vs%YEAR%_compiler_vars.bat
 sed -i 's/@update_version@/%update_version%/g' vs%YEAR%_compiler_vars.bat
 sed -i 's/@cross_compiler_target_platform@/%cross_compiler_target_platform%/g' vs%YEAR%_compiler_vars.bat
 sed -i 's/@tools_version@/%tools_version%/g' vs%YEAR%_compiler_vars.bat
+sed -i 's/@msvc_version@/%msvc_version%/g' vs%YEAR%_compiler_vars.bat
 popd
 
 :: Deactivation script

--- a/recipe/install_runtime.bat
+++ b/recipe/install_runtime.bat
@@ -10,7 +10,7 @@ if "%ARCH%"=="64" (
 set MSC_VER=2022
 
 REM ========== This one comes from visual studio 2022
-set "VC_VER=143"
+set "VC_VER=%msvc_version%"
 
 set "BT_ROOT="
 for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version ^[17.0^,18.0^] -property installationPath`) do (

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 build:
   skip: True # [not win]
-  number: 4
+  number: 5
 
 outputs:
   - name: vs{{ vsyear }}_{{ cross_compiler_target_platform }}


### PR DESCRIPTION
vs2022 14.42 b5

**Destination channel:** defaults

### Links

- [PKG-7630](https://anaconda.atlassian.net/browse/PKG-7630)
- Relevant dependency PRs:
  - anaconda-distribution/rocket-platform#1459

### Explanation of changes:

- Pin activation scripts to using MSVC v143 14.42
  - Latest MSVC v143 14.43 seems to lack a dedicated runtime and causes memory faults with QtWebEngine builds
  - Keeping a constant version pinned ensures we can update our CI images and activation feedstocks simultaneously and avoids disjoint scenarios such as the latest MSVC being installed in CI but working with the runtime installed via this feedstock's packages


[PKG-7630]: https://anaconda.atlassian.net/browse/PKG-7630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ